### PR TITLE
Feature/new bias maker and test

### DIFF
--- a/banzai_nres/bias.py
+++ b/banzai_nres/bias.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from banzai.bias import BiasMaker as BanzaiBiasMaker
+
 import os.path
 
 import numpy as np
@@ -12,24 +14,14 @@ from banzai.utils import stats, fits_utils
 from scipy.ndimage import filters
 
 
-
-class BiasMaker(CalibrationMaker):
-
+class BiasMaker(BanzaiBiasMaker):
     def __init__(self, pipeline_context):
         super(BiasMaker, self).__init__(pipeline_context)
 
     @property
-    def group_by_keywords(self):
-        return ['ccdsum']
-
-    @property
-    def calibration_type(self):
-        return 'BIAS'
-
-    @property
     def min_images(self):
         return 5
-
+    #  master calibration frame is imported because soon I will include variance calculations as I did with dark.
     def make_master_calibration_frame(self, images, image_config, logging_tags):
 
         bias_data = np.zeros((image_config.ny, image_config.nx, len(images)), dtype=np.float32)

--- a/banzai_nres/tests/test_bias_maker.py
+++ b/banzai_nres/tests/test_bias_maker.py
@@ -4,24 +4,17 @@ import numpy as np
 from astropy.io import fits
 
 from banzai.tests.utils import FakeImage, FakeContext, throws_inhomogeneous_set_exception
+from banzai.tests.test_bias_maker import FakeBiasImage
 
 import mock
 
 """
-This tests BiasMaker.
-It is almost an exact copy of Banzai's test_bias_maker by cmcully.
+This tests BiasMaker. This is almost an exact copy of the banzai test.bias.
+Functions are only explicitly copied because the @mock.patch needs to point to the correct object type.
 
 The only changes are the error margins, which are now fractional errors,
 inside of test_makes_a_sensible_master_bias
 """
-
-class FakeBiasImage(FakeImage):
-    def __init__(self, *args, **kwargs):
-        super(FakeBiasImage, self).__init__(*args, **kwargs)
-        self.caltype = 'bias'
-        self.header = fits.Header()
-        self.header['OBSTYPE'] = 'BIAS'
-
 
 def test_min_images():
     bias_maker = BiasMaker(None)
@@ -64,22 +57,22 @@ def test_header_cal_type_bias(mock_image):
 
 
 @mock.patch('banzai_nres.bias.Image')
-def test_raises_an_exection_if_ccdsums_are_different(mock_images):
+def test_raises_an_exception_if_ccdsums_are_different(mock_images):
     throws_inhomogeneous_set_exception(BiasMaker, FakeContext(), 'ccdsum', '1 1')
 
 
 @mock.patch('banzai_nres.bias.Image')
-def test_raises_an_exection_if_epochs_are_different(mock_images):
+def test_raises_an_exception_if_epochs_are_different(mock_images):
     throws_inhomogeneous_set_exception(BiasMaker, FakeContext(), 'epoch', '20160102')
 
 
 @mock.patch('banzai_nres.bias.Image')
-def test_raises_an_exection_if_nx_are_different(mock_images):
+def test_raises_an_exception_if_nx_are_different(mock_images):
     throws_inhomogeneous_set_exception(BiasMaker, FakeContext(), 'nx', 105)
 
 
 @mock.patch('banzai_nres.bias.Image')
-def test_raises_an_exection_if_ny_are_different(mock_images):
+def test_raises_an_exception_if_ny_are_different(mock_images):
     throws_inhomogeneous_set_exception(BiasMaker, FakeContext(), 'ny', 107)
 
 
@@ -110,5 +103,5 @@ def test_makes_a_sensible_master_bias(mock_images):
     assert np.abs((actual_bias - expected_bias)/expected_bias) < 1E-3
     actual_readnoise = np.std(master_bias)
     assert np.abs((actual_readnoise - expected_readnoise / (nimages ** 0.5))/actual_readnoise) < 6E-2
-    # expected_readnoise / (nimages ** 0.5) is just the theoretical std after averageing
+    # expected_readnoise / (nimages ** 0.5) is just the theoretical std after averaging
     # of sqr_root(Var((1/n) \sum_n X_n))

--- a/setup.py
+++ b/setup.py
@@ -9,13 +9,13 @@ License
     GPL v3.0
 July 2018
 """
-from setuptools import setup
+from setuptools import setup, find_packages
 
 setup(name='banzai_nres',
       author=['Curtis McCully', 'G. Mirek Brandt', 'Timothy D. Brandt'],
       author_email=['cmccully@lco.global', 'gmbrandt@ucsb.edu', 'tbrandt@physics.ucsb.edu'],
       version='0.1.0',
-      packages=['banzai_nres'],
+      packages=find_packages(),
       package_dir={'banzai_nres': 'banzai_nres'},
       setup_requires=['pytest-runner'],
       install_requires=['banzai', 'scipy'],


### PR DESCRIPTION
Copies the banzai Biasmaker into a new py file bias.py. Sets up the unit-test (although not the quality metric) for the banzai_nres biasmaker (Which currently is just a duplicate of the banzai one). The unit test runs successfully on jenkins.