### PR TITLE
Update docker-compose to reflect env var name changes in upstream BANZAI.

### DIFF
--- a/banzai_nres/tests/test_e2e.py
+++ b/banzai_nres/tests/test_e2e.py
@@ -46,11 +46,11 @@ def celery_join():
     celery_inspector = app.control.inspect()
     log_counter = 0
     while True:
-        queues = [celery_inspector.active(), celery_inspector.scheduled(), celery_inspector.reserved()]
         time.sleep(1)
         log_counter += 1
         if log_counter % 5 == 0:
             logger.info('Processing: ' + '. ' * (log_counter // 5))
+        queues = [celery_inspector.active(), celery_inspector.scheduled(), celery_inspector.reserved()]
         if any([queue is None or 'celery@banzai-celery-worker' not in queue for queue in queues]):
             logger.warning('No valid celery queues were detected, retrying...', extra_tags={'queues': queues})
             # Reset the celery connection

--- a/banzai_nres/tests/test_e2e.py
+++ b/banzai_nres/tests/test_e2e.py
@@ -17,7 +17,7 @@ from astropy.io import fits
 
 import logging
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger('banzai')
 
 TEST_PACKAGE = 'banzai_nres.tests'
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,8 +49,8 @@ services:
       - nres-e2e-data
     environment:
       RETRY_DELAY: "0"
-      REDIS_HOST: "redis://redis:6379/0"
-      LAKE_URL: "http://lake-old.lco.gtn/blocks/"
+      TASK_HOST: "redis://redis:6379/0"
+      OBSERVATION_PORTAL_URL: "http://lake-old.lco.gtn/blocks/"
       NUM_OMP_THREADS: "1"
       OPENTSDB_PYTHON_METRICS_TEST_MODE: "1"
     labels:
@@ -77,11 +77,11 @@ services:
                  "--broker-url=broker"]
     environment:
       DB_ADDRESS: sqlite:////archive/engineering/test.db
-      REDIS_HOST: "redis://redis:6379/0"
+      TASK_HOST: "redis://redis:6379/0"
       FITS_EXCHANGE: fits_files
       FITS_BROKER: broker
       OPENTSDB_PYTHON_METRICS_TEST_MODE: "1"
-      LAKE_URL: "http://lake-old.lco.gtn/blocks/"
+      OBSERVATION_PORTAL_URL: "http://lake-old.lco.gtn/blocks/"
     volumes_from:
     - nres-e2e-data
     labels:


### PR DESCRIPTION
The docker-compose for BANZAI-NRES is out of sync with the dev version of BANZAI. This fixes some environment variables to match the upstream BANZAI docker-compose.