### PR TITLE
Allocate ephemeral storage to worker container.

### DIFF
--- a/banzai_nres/settings.py
+++ b/banzai_nres/settings.py
@@ -78,7 +78,7 @@ OBSERVATION_REQUEST_TYPES = {'BIAS': 'NRESBIAS', 'DARK': 'NRESDARK'}
 # For some extension names, we want to just have corresponding BPM or ERR extensions
 EXTENSION_NAMES_TO_CONDENSE = ['SPECTRUM']
 
-CALIBRATION_LOOKBACK = {'BIAS': 4.5, 'DARK': 4.5, 'LAMPFLAT': 0.5}
+CALIBRATION_LOOKBACK = {'BIAS': 2.5, 'DARK': 4.5, 'LAMPFLAT': 0.5}
 
 PIPELINE_VERSION = banzai_nres.__version__
 

--- a/helm-chart/banzai-nres/templates/workers.yaml
+++ b/helm-chart/banzai-nres/templates/workers.yaml
@@ -106,9 +106,11 @@ spec:
             requests:
               cpu: "0.3"
               memory: "1Gi"
+              ephemeral-storage: "16Gi"
             limits:
               cpu: "3"
               memory: "4Gi"
+              ephemeral-storage: "32Gi"
     {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
When stacking large numbers of frames, banzai-nres uses tempfiles to reduce memory usage.
However, pods were getting evicted because the size of these tempfiles were vastly overrunning the default limit.