### PR TITLE
Fix/add classification details

### DIFF
--- a/banzai_nres/classify.py
+++ b/banzai_nres/classify.py
@@ -109,9 +109,9 @@ class StellarClassifier(Stage):
         else:
             image.meta['CLASSIFY'] = 1, 'Was this spectrum classified'
             dbs.save_classification(self.runtime_context.db_address, image)
-        image.meta['TEFF'] = image.classification.T_effective
-        image.meta['LOG_G'] = image.classification.log_g
-        image.meta['FEH'] = image.classification.metallicity
-        image.meta['ALPHA'] = image.classification.alpha
+        image.meta['TEFF'] = image.classification.T_effective, 'Estimated stellar effective temperature [K]'
+        image.meta['LOG_G'] = image.classification.log_g, 'Estimated stellar surface gravity [cgs]'
+        image.meta['FEH'] = image.classification.metallicity, 'Estimated stellar metallicity [dex]'
+        image.meta['ALPHA'] = image.classification.alpha, 'Estimated stellar alpha abundance [dex]'
 
         return image

--- a/banzai_nres/classify.py
+++ b/banzai_nres/classify.py
@@ -110,7 +110,7 @@ class StellarClassifier(Stage):
             image.meta['CLASSIFY'] = 1, 'Was this spectrum classified'
             dbs.save_classification(self.runtime_context.db_address, image)
         image.meta['TEFF'] = image.classification.T_effective, 'Estimated stellar effective temperature [K]'
-        image.meta['LOG_G'] = image.classification.log_g, 'Estimated stellar surface gravity [cgs]'
+        image.meta['LOGG'] = image.classification.log_g, 'Estimated stellar surface gravity [cgs]'
         image.meta['FEH'] = image.classification.metallicity, 'Estimated stellar metallicity [dex]'
         image.meta['ALPHA'] = image.classification.alpha, 'Estimated stellar alpha abundance [dex]'
 

--- a/banzai_nres/frames.py
+++ b/banzai_nres/frames.py
@@ -222,6 +222,7 @@ class NRESObservationFrame(LCOObservationFrame):
             # Proper motion is stored in arcseconds/year but we always use it in mas/year
             # Note that the RA proper motion has the cos dec term included both in the header and when we use it
             self.primary_hdu.meta['PM-RA'] = value / 1000.0
+        self.primary_hdu.meta['PM-RA'].comments = 'Right ascension proper motion from Gaia [mas/yr]'
 
     @property
     def pm_dec(self):
@@ -239,6 +240,7 @@ class NRESObservationFrame(LCOObservationFrame):
         else:
             # Proper motion is stored in arcseconds/year but we always use it in mas/year
             self.primary_hdu.meta['PM-DEC'] = value / 1000.0
+        self.primary_hdu.meta['PM-DEC'].comments = 'Declination proper motion from Gaia [mas/yr]'
 
     @property
     def classification(self):

--- a/banzai_nres/frames.py
+++ b/banzai_nres/frames.py
@@ -251,12 +251,12 @@ class NRESObservationFrame(LCOObservationFrame):
         self._classification = value
         if value is not None:
             self.meta['TEFF'] = value.T_effective
-            self.meta['LOG_G'] = value.log_g
+            self.meta['LOGG'] = value.log_g
             self.meta['FEH'] = value.metallicity
             self.meta['ALPHA'] = value.alpha
         else:
             self.meta['TEFF'] = ''
-            self.meta['LOG_G'] = ''
+            self.meta['LOGG'] = ''
             self.meta['FEH'] = ''
             self.meta['ALPHA'] = ''
 

--- a/banzai_nres/frames.py
+++ b/banzai_nres/frames.py
@@ -222,7 +222,7 @@ class NRESObservationFrame(LCOObservationFrame):
             # Proper motion is stored in arcseconds/year but we always use it in mas/year
             # Note that the RA proper motion has the cos dec term included both in the header and when we use it
             self.primary_hdu.meta['PM-RA'] = value / 1000.0
-        self.primary_hdu.meta.comments['PM-RA'] = 'RA proper motion from Gaia [mas/yr * cos(delta)]'
+        self.primary_hdu.meta.comments['PM-RA'] = 'RA proper motion from Gaia [mas/yr * cos(Dec)]'
 
     @property
     def pm_dec(self):

--- a/banzai_nres/frames.py
+++ b/banzai_nres/frames.py
@@ -250,12 +250,12 @@ class NRESObservationFrame(LCOObservationFrame):
         if value is not None:
             self.meta['TEFF'] = value.T_effective
             self.meta['LOG_G'] = value.log_g
-            self.meta['FE_H'] = value.metallicity
+            self.meta['FEH'] = value.metallicity
             self.meta['ALPHA'] = value.alpha
         else:
             self.meta['TEFF'] = ''
             self.meta['LOG_G'] = ''
-            self.meta['FE_H'] = ''
+            self.meta['FEH'] = ''
             self.meta['ALPHA'] = ''
 
 

--- a/banzai_nres/frames.py
+++ b/banzai_nres/frames.py
@@ -222,7 +222,7 @@ class NRESObservationFrame(LCOObservationFrame):
             # Proper motion is stored in arcseconds/year but we always use it in mas/year
             # Note that the RA proper motion has the cos dec term included both in the header and when we use it
             self.primary_hdu.meta['PM-RA'] = value / 1000.0
-        self.primary_hdu.meta.comments['PM-RA'] = 'RA proper motion from Gaia [mas/yr]'
+        self.primary_hdu.meta.comments['PM-RA'] = 'RA proper motion from Gaia [mas/yr * cos(delta)]'
 
     @property
     def pm_dec(self):

--- a/banzai_nres/frames.py
+++ b/banzai_nres/frames.py
@@ -222,7 +222,7 @@ class NRESObservationFrame(LCOObservationFrame):
             # Proper motion is stored in arcseconds/year but we always use it in mas/year
             # Note that the RA proper motion has the cos dec term included both in the header and when we use it
             self.primary_hdu.meta['PM-RA'] = value / 1000.0
-        self.primary_hdu.meta['PM-RA'].comments = 'Right ascension proper motion from Gaia [mas/yr]'
+        self.primary_hdu.meta.comments['PM-RA'] = 'RA proper motion from Gaia [mas/yr]'
 
     @property
     def pm_dec(self):
@@ -240,7 +240,7 @@ class NRESObservationFrame(LCOObservationFrame):
         else:
             # Proper motion is stored in arcseconds/year but we always use it in mas/year
             self.primary_hdu.meta['PM-DEC'] = value / 1000.0
-        self.primary_hdu.meta['PM-DEC'].comments = 'Declination proper motion from Gaia [mas/yr]'
+        self.primary_hdu.meta.comments['PM-DEC'] = 'Dec proper motion from Gaia [mas/yr]'
 
     @property
     def classification(self):


### PR DESCRIPTION
This PR fixes two minor issues with the information in the FITS headers for the reduced spectra:

- Added explanations in the comment fields for the header keywords TEFF, LOG_G, FEH, ALPHA, PM-RA and PM-DEC in order to be consistent with the other header keywords and provide a ready reference for end users.
- Fixed inconsistent usage of FEH versus FE_H in the header keywords.