### PR TITLE
added logic for traces to ignore edge clips and pixels in the bpm

### DIFF
--- a/banzai_nres/settings.py
+++ b/banzai_nres/settings.py
@@ -170,6 +170,3 @@ MAX_ORDER_TO_CORRELATE = 97
 GAIA_CLASS = os.getenv('BANZAI_GAIA_CLASS', 'astroquery.gaia.GaiaClass')
 
 SIMBAD_CLASS = os.getenv('BANZAI_SIMBAD', 'astroquery.simbad.Simbad')
-
-# The final trace will be +- this from the center in the y-direction
-TRACE_HALF_HEIGHT = 5

--- a/banzai_nres/tests/test_traces.py
+++ b/banzai_nres/tests/test_traces.py
@@ -55,7 +55,7 @@ def test_blind_solve():
 
 
 def test_blind_solve_with_bpm():
-    trace_centers, test_data, x2d, y2d = make_realistic_trace_image(y0_centers=[100, 200, 300])
+    trace_centers, test_data, x2d, y2d = make_realistic_trace_image()
     bpm_mask = np.ones_like(test_data, dtype=bool)
     bpm_mask[150:250, :] = 0  # set the pixels around the center trace as good. Leave the other pixels masked.
     test_image = NRESObservationFrame([EchelleSpectralCCDData(data=test_data, uncertainty=1e-5*np.ones_like(test_data),

--- a/docs/banzai_nres/development.rst
+++ b/docs/banzai_nres/development.rst
@@ -31,3 +31,9 @@ Testing on Real Data
 --------------------
 Generally, the simplest way to reduce data with BANZAI-NRES is to follow the example reduction on the next page.
 For more complex setups that use RabbitMQ and celery, see the helm chart of deployment details.
+
+Notes on settings
+-----------------
+Data reduction settings can be modified within the settings.py file. TRACE_HALF_HEIGHT sets half the height
+of the trace regions (the regions that encompass each spectral order on the detector). It is set to 5 by default. This
+value covers the orders more than sufficiently. Changing this value may break the tracing part of the pipeline.

--- a/docs/banzai_nres/development.rst
+++ b/docs/banzai_nres/development.rst
@@ -35,5 +35,6 @@ For more complex setups that use RabbitMQ and celery, see the helm chart of depl
 Notes on settings
 -----------------
 Data reduction settings can be modified within the settings.py file. TRACE_HALF_HEIGHT sets half the height
-of the trace regions (the regions that encompass each spectral order on the detector). It is set to 5 by default. This
-value covers the orders more than sufficiently. Changing this value may break the tracing part of the pipeline.
+of the trace regions in pixels (the regions that encompass each spectral order on the detector). It is set to 5 pixels
+by default. This value covers the orders more than sufficiently. Changing this value may break
+the tracing part of the pipeline.

--- a/docs/banzai_nres/development.rst
+++ b/docs/banzai_nres/development.rst
@@ -31,10 +31,3 @@ Testing on Real Data
 --------------------
 Generally, the simplest way to reduce data with BANZAI-NRES is to follow the example reduction on the next page.
 For more complex setups that use RabbitMQ and celery, see the helm chart of deployment details.
-
-Notes on settings
------------------
-Data reduction settings can be modified within the settings.py file. TRACE_HALF_HEIGHT sets half the height
-of the trace regions in pixels (the regions that encompass each spectral order on the detector). It is set to 5 pixels
-by default. This value covers the orders more than sufficiently. Changing this value may break
-the tracing part of the pipeline.


### PR DESCRIPTION
This PR resolves an issue with traces. Traces were allowed to clip off the edges of the detectors, and tracing did not respect the bad pixel mask (bpm). Tracing now ignores traces that clip the bottom or top of the detector, or fall into the bpm.