### PR TITLE
Calculate the SNR for the science spectra

### DIFF
--- a/banzai_nres/qc/qc_science.py
+++ b/banzai_nres/qc/qc_science.py
@@ -22,7 +22,6 @@ class CalculateScienceFrameMetrics(Stage):
         return image
 
 def get_snr(image, order):
-    snr_all = image.spectrum[image.science_fiber,order]['flux']/image.spectrum[image.science_fiber,order]['uncertainty']
-    #Take the peak SNR over the middle 1/4 of the chip
-    snr = np.mean(snr_all[int(image.shape[1]*3/8):int(image.shape[1]*5/8)])
+    snr_all = image.spectrum[image.science_fiber,order]['flux'] / image.spectrum[image.science_fiber,order]['uncertainty']
+    snr = np.percentile(snr_all,90)
     return snr

--- a/banzai_nres/qc/qc_science.py
+++ b/banzai_nres/qc/qc_science.py
@@ -1,0 +1,27 @@
+import numpy as np
+from banzai.stages import Stage
+import logging
+
+logger = logging.getLogger('banzai')
+
+#This defines the order for which we calculate the SNR value for the header.
+#By default this is the order containing the Mg b lines.
+SNR_ORDER = 90 
+
+
+class CalculateScienceFrameMetrics(Stage):
+
+    def __init__(self, runtime_context):
+        super(CalculateScienceFrameMetrics, self).__init__(runtime_context)
+
+    def do_stage(self, image):
+        snr = get_snr(image, SNR_ORDER)
+        image.meta['SNR'] = snr, 'Signal-to-noise ratio at 5180 Angstroms'
+
+        return image
+
+    def get_snr(image, order):
+        snr_all = image.spectrum[image.science_fiber,order]['flux']/image.spectrum[image.science_fiber,order]['uncertainty']
+        #Take the peak SNR over the middle 1/4 of the chip
+        snr = np.mean(snr_all[image.shape[1]*3./8.:image.shape[1]*5./8.])
+        return snr

--- a/banzai_nres/qc/qc_science.py
+++ b/banzai_nres/qc/qc_science.py
@@ -1,13 +1,12 @@
 import numpy as np
 from banzai.stages import Stage
-from banzai.utils import qc
 import logging
 
 logger = logging.getLogger('banzai')
 
-#This defines the order for which we calculate the SNR value for the header.
-#By default this is the order containing the Mg b lines.
-SNR_ORDER = 90 
+# This defines the order for which we calculate the SNR value for the header.
+# By default this is the order containing the Mg b lines.
+SNR_ORDER = 90
 
 
 class CalculateScienceFrameMetrics(Stage):
@@ -21,7 +20,8 @@ class CalculateScienceFrameMetrics(Stage):
 
         return image
 
+
 def get_snr(image, order):
-    snr_all = image.spectrum[image.science_fiber,order]['flux'] / image.spectrum[image.science_fiber,order]['uncertainty']
-    snr = np.percentile(snr_all,90)
+    snr_all = image.spectrum[image.science_fiber, order]['flux'] / image.spectrum[image.science_fiber, order]['uncertainty']
+    snr = np.percentile(snr_all, 90)
     return snr

--- a/banzai_nres/qc/qc_science.py
+++ b/banzai_nres/qc/qc_science.py
@@ -1,5 +1,6 @@
 import numpy as np
 from banzai.stages import Stage
+from banzai.utils import qc
 import logging
 
 logger = logging.getLogger('banzai')
@@ -20,8 +21,8 @@ class CalculateScienceFrameMetrics(Stage):
 
         return image
 
-    def get_snr(image, order):
-        snr_all = image.spectrum[image.science_fiber,order]['flux']/image.spectrum[image.science_fiber,order]['uncertainty']
-        #Take the peak SNR over the middle 1/4 of the chip
-        snr = np.mean(snr_all[image.shape[1]*3./8.:image.shape[1]*5./8.])
-        return snr
+def get_snr(image, order):
+    snr_all = image.spectrum[image.science_fiber,order]['flux']/image.spectrum[image.science_fiber,order]['uncertainty']
+    #Take the peak SNR over the middle 1/4 of the chip
+    snr = np.mean(snr_all[int(image.shape[1]*3/8):int(image.shape[1]*5/8)])
+    return snr

--- a/banzai_nres/qc/qc_science.py
+++ b/banzai_nres/qc/qc_science.py
@@ -22,6 +22,7 @@ class CalculateScienceFrameMetrics(Stage):
 
 
 def get_snr(image, order):
-    snr_all = image.spectrum[image.science_fiber, order]['flux'] / image.spectrum[image.science_fiber, order]['uncertainty']
+    snr_all = image.spectrum[image.science_fiber, order]['flux'] / \
+              image.spectrum[image.science_fiber, order]['uncertainty']
     snr = np.percentile(snr_all, 90)
     return snr

--- a/banzai_nres/settings.py
+++ b/banzai_nres/settings.py
@@ -24,7 +24,7 @@ ORDERED_STAGES = [
                   'banzai_nres.continuum.MaskBlueHookRegion',
                   'banzai_nres.continuum.ContinuumNormalizer',
                   'banzai_nres.continuum.MaskTellurics',
-                  'banzai_nres.qc.qc_science.CalculateScienceFrameMetrics'
+                  'banzai_nres.qc.qc_science.CalculateScienceFrameMetrics',
                   'banzai_nres.classify.StellarClassifier',
                   'banzai_nres.rv.RVCalculator'
                   ]

--- a/banzai_nres/settings.py
+++ b/banzai_nres/settings.py
@@ -24,6 +24,7 @@ ORDERED_STAGES = [
                   'banzai_nres.continuum.MaskBlueHookRegion',
                   'banzai_nres.continuum.ContinuumNormalizer',
                   'banzai_nres.continuum.MaskTellurics',
+                  'banzai_nres.qc.qc_science.CalculateScienceFrameMetrics'
                   'banzai_nres.classify.StellarClassifier',
                   'banzai_nres.rv.RVCalculator'
                   ]

--- a/banzai_nres/tests/test_qc_science.py
+++ b/banzai_nres/tests/test_qc_science.py
@@ -1,0 +1,26 @@
+import numpy as np
+
+from banzai import context
+from banzai.nres.qc.qc_science import CalculateScienceFrameMetrics
+from banzai.nres.qc.qc_science import get_snr
+from banzai_nres.frames import NRESObservationFrame
+from banzai_nres.frames import EchelleSpectralCCDData, Spectrum1D
+
+class TestCalculateScienceFrameMetrics:
+    nput_context = context.Context({})
+    test_wavelengths = np.linspace(5100.0,5200.0,4096)
+    test_flux =  -0.001 * test_wavelengths**2 + 10.3 * test_wavelengths
+    test_uncertainty = np.sqrt(test_flux)
+    snr_order = 90
+    spectrum = {'wavelength': test_wavelengths, 'flux': test_flux, 'uncertainty': test_uncertainty, 'fiber': 0, 'order': snr_order}
+    image = NRESObservationFrame([EchelleSpectralCCDData(np.zeros((1, 1)), spectrum=Spectrum1D(spectrum))], science_fiber=0,
+                                 'test.fits')
+    
+
+    def test_do_stage_does_not_crash(self):
+        image = CalculateScienceFrameMetrics(self.input_context).do_stage(self.test_image)
+        assert image is not None
+
+    def test_snr_calculation(self):
+        snr = get_snr(image,snr_order)
+        assert np.isclose(snr, np.max(test_flux/test_uncertainty), rtol=0.1)

--- a/banzai_nres/tests/test_qc_science.py
+++ b/banzai_nres/tests/test_qc_science.py
@@ -6,26 +6,27 @@ from banzai_nres.qc.qc_science import get_snr
 from banzai_nres.frames import NRESObservationFrame
 from banzai_nres.frames import EchelleSpectralCCDData, Spectrum1D
 
+
 class TestCalculateScienceFrameMetrics:
     input_context = context.Context({})
-    test_wavelengths = np.linspace(5100.0,5200.0,4096)
-    test_flux =  -0.001 * test_wavelengths**2 + 10.3 * test_wavelengths
+    test_wavelengths = np.linspace(5100.0, 5200.0, 4096)
+    test_flux = -0.001 * test_wavelengths**2 + 10.3 * test_wavelengths
     test_uncertainty = np.sqrt(test_flux)
     snr_order = 90
     spectrum = []
     header = fits.Header({'OBJECTS': 'test&none&none'})
     for i in range(5):
         order = snr_order + i
-        row = {'wavelength': test_wavelengths, 'flux': test_flux, 'uncertainty': test_uncertainty, 'fiber': 0, 'order': snr_order}
+        row = {'wavelength': test_wavelengths, 'flux': test_flux, 'uncertainty': test_uncertainty,
+                        'fiber': 0, 'order': snr_order}
         spectrum.append(row)
-    test_image = NRESObservationFrame([EchelleSpectralCCDData(np.zeros((1, 1)), meta=header, spectrum=Spectrum1D(spectrum))],
-                                 'test.fits')
-    
+    test_image = NRESObservationFrame([EchelleSpectralCCDData(np.zeros((1, 1)), meta=header,
+                                                    spectrum=Spectrum1D(spectrum))], 'test.fits')
 
     def test_do_stage_does_not_crash(self):
         image = CalculateScienceFrameMetrics(self.input_context).do_stage(self.test_image)
         assert image is not None
 
     def test_snr_calculation(self):
-        snr = get_snr(self.test_image,self.snr_order)
+        snr = get_snr(self.test_image, self.snr_order)
         assert np.isclose(snr, np.max(self.test_flux/self.test_uncertainty), rtol=0.1)

--- a/banzai_nres/tests/test_qc_science.py
+++ b/banzai_nres/tests/test_qc_science.py
@@ -18,10 +18,10 @@ class TestCalculateScienceFrameMetrics:
     for i in range(5):
         order = snr_order + i
         row = {'wavelength': test_wavelengths, 'flux': test_flux, 'uncertainty': test_uncertainty,
-                        'fiber': 0, 'order': snr_order}
+               'fiber': 0, 'order': snr_order}
         spectrum.append(row)
     test_image = NRESObservationFrame([EchelleSpectralCCDData(np.zeros((1, 1)), meta=header,
-                                                    spectrum=Spectrum1D(spectrum))], 'test.fits')
+                                                              spectrum=Spectrum1D(spectrum))], 'test.fits')
 
     def test_do_stage_does_not_crash(self):
         image = CalculateScienceFrameMetrics(self.input_context).do_stage(self.test_image)

--- a/banzai_nres/tests/test_qc_science.py
+++ b/banzai_nres/tests/test_qc_science.py
@@ -1,19 +1,24 @@
 import numpy as np
-
+from astropy.io import fits
 from banzai import context
-from banzai.nres.qc.qc_science import CalculateScienceFrameMetrics
-from banzai.nres.qc.qc_science import get_snr
+from banzai_nres.qc.qc_science import CalculateScienceFrameMetrics
+from banzai_nres.qc.qc_science import get_snr
 from banzai_nres.frames import NRESObservationFrame
 from banzai_nres.frames import EchelleSpectralCCDData, Spectrum1D
 
 class TestCalculateScienceFrameMetrics:
-    nput_context = context.Context({})
+    input_context = context.Context({})
     test_wavelengths = np.linspace(5100.0,5200.0,4096)
     test_flux =  -0.001 * test_wavelengths**2 + 10.3 * test_wavelengths
     test_uncertainty = np.sqrt(test_flux)
     snr_order = 90
-    spectrum = {'wavelength': test_wavelengths, 'flux': test_flux, 'uncertainty': test_uncertainty, 'fiber': 0, 'order': snr_order}
-    image = NRESObservationFrame([EchelleSpectralCCDData(np.zeros((1, 1)), spectrum=Spectrum1D(spectrum))], science_fiber=0,
+    spectrum = []
+    header = fits.Header({'OBJECTS': 'test&none&none'})
+    for i in range(5):
+        order = snr_order + i
+        row = {'wavelength': test_wavelengths, 'flux': test_flux, 'uncertainty': test_uncertainty, 'fiber': 0, 'order': snr_order}
+        spectrum.append(row)
+    test_image = NRESObservationFrame([EchelleSpectralCCDData(np.zeros((1, 1)), meta=header, spectrum=Spectrum1D(spectrum))],
                                  'test.fits')
     
 
@@ -22,5 +27,5 @@ class TestCalculateScienceFrameMetrics:
         assert image is not None
 
     def test_snr_calculation(self):
-        snr = get_snr(image,snr_order)
-        assert np.isclose(snr, np.max(test_flux/test_uncertainty), rtol=0.1)
+        snr = get_snr(self.test_image,self.snr_order)
+        assert np.isclose(snr, np.max(self.test_flux/self.test_uncertainty), rtol=0.1)


### PR DESCRIPTION
The primary purpose of this PR is to enable the code to calculate the signal-to-noise ratio for the science spectra and put this information in the FITS headers. The secondary purpose is to establish a framework to calculate additional quality control metrics from the science spectra in the future.