### PR TITLE
Update BANZAI-NRES deployment to use BANZAI rabbitmq host.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+1.0.1 (2021-05-24)
+------------------
+- Add ability to configure task queue name (BANZAI 1.3.2)
+
+1.0.0 (2021-05-13)
+------------------
+- Initial release
+
 0.5.1 (2020-05-07)
 ------------------
 - Extracted spectra now have wavelengths attached.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.lco.global/banzai:1.3.0
+FROM docker.lco.global/banzai:1.3.0-15-gfc67aac
 
 USER root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.lco.global/banzai:1.3.0-15-gfc67aac
+FROM docker.lco.global/banzai:1.3.2
 
 USER root
 

--- a/banzai_nres/settings.py
+++ b/banzai_nres/settings.py
@@ -177,3 +177,5 @@ MAX_ORDER_TO_CORRELATE = 97
 GAIA_CLASS = os.getenv('BANZAI_GAIA_CLASS', 'astroquery.gaia.GaiaClass')
 
 SIMBAD_CLASS = os.getenv('BANZAI_SIMBAD', 'astroquery.simbad.Simbad')
+
+CELERY_TASK_QUEUE_NAME = os.getenv('CELERY_TASK_QUEUE_NAME', 'celery')

--- a/helm-chart/banzai-nres-e2e/Chart.yaml
+++ b/helm-chart/banzai-nres-e2e/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "1.0.1"
+appVersion: "latest"
 description: A Helm chart for end to end tests for BANZAI-nres
 name: banzai-nres-e2e
-version: 1.0.1
+version: 1.0.0

--- a/helm-chart/banzai-nres-e2e/Chart.yaml
+++ b/helm-chart/banzai-nres-e2e/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "latest"
+appVersion: "1.0.1"
 description: A Helm chart for end to end tests for BANZAI-nres
 name: banzai-nres-e2e
-version: 1.0.0
+version: 1.0.1

--- a/helm-chart/banzai-nres-e2e/templates/e2e_tests.yaml
+++ b/helm-chart/banzai-nres-e2e/templates/e2e_tests.yaml
@@ -115,6 +115,8 @@ spec:
                 secretKeyRef:
                   name: banzai-nres-secrets
                   key: AWS_SECRET_ACCESS_KEY
+            - name: CELERY_TASK_QUEUE_NAME
+              value: "e2e_task_queue"
           command:
             - celery
             - -A
@@ -169,6 +171,8 @@ spec:
                 secretKeyRef:
                   name: banzai-nres-secrets
                   key: AWS_SECRET_ACCESS_KEY
+            - name: CELERY_TASK_QUEUE_NAME
+              value: "e2e_task_queue"
           command:
             - banzai_nres_run_realtime_pipeline
             - "--db-address=sqlite:////archive/engineering/test.db"

--- a/helm-chart/banzai-nres-e2e/templates/e2e_tests.yaml
+++ b/helm-chart/banzai-nres-e2e/templates/e2e_tests.yaml
@@ -128,6 +128,8 @@ spec:
             - "2"
             - --loglevel
             - "DEBUG"
+            - -Q
+            - "$(CELERY_TASK_QUEUE_NAME)"
           resources:
             requests:
               cpu: "0.1"

--- a/helm-chart/banzai-nres/Chart.yaml
+++ b/helm-chart/banzai-nres/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "1.0.0"
+appVersion: "1.0.1"
 description: A Helm chart to deploy the BANZAI-NRES pipeline
 name: banzai-nres
-version: 1.0.0
+version: 1.0.1

--- a/helm-chart/banzai-nres/templates/_helpers.tpl
+++ b/helm-chart/banzai-nres/templates/_helpers.tpl
@@ -171,6 +171,8 @@ Celery task queue configuration
   value: {{ .Values.banzaiNres.fitsExchange | quote }}
 - name: QUEUE_NAME
   value: {{ .Values.banzaiNres.queueName | quote }}
+- name: CELERY_TASK_QUEUE_NAME
+  value: {{ .Values.banzaiNres.celeryTaskQueueName | quote }}
 - name: BANZAI_WORKER_LOGLEVEL
   value: {{ .Values.banzaiNres.banzaiWorkerLogLevel | quote }}
 - name: PHOENIX_FILE_LOCATION

--- a/helm-chart/banzai-nres/templates/workers.yaml
+++ b/helm-chart/banzai-nres/templates/workers.yaml
@@ -35,6 +35,8 @@ spec:
             - "1"
             - "-l"
             - "info"
+            - "-Q"
+            - "$(CELERY_TASK_QUEUE_NAME)"
           env:
             - name: OMP_NUM_THREADS
               value: "2"

--- a/helm-chart/banzai-nres/values-dev.yaml
+++ b/helm-chart/banzai-nres/values-dev.yaml
@@ -12,7 +12,7 @@ horizontalPodAutoscaler:
 
 image:
   repository: docker.lco.global/banzai-nres
-  tag: "1.0.0"
+  tag: "1.0.1"
   pullPolicy: IfNotPresent
 
 # Values for the OCS Ingester library, used by BANZAI.

--- a/helm-chart/banzai-nres/values-dev.yaml
+++ b/helm-chart/banzai-nres/values-dev.yaml
@@ -35,6 +35,7 @@ banzaiNres:
   fitsExchange: archived_fits
   queueName: banzai_nres_dev_pipeline
   phoenixFileLocation: s3://banzai-nres-phoenix-models-lco-global
+  celeryTaskQueueName: banzai_nres
 
 # CronJob configuration to periodically update instrument table in BANZAI-NRES DB
 instrumentTableCronjob:

--- a/helm-chart/banzai-nres/values-prod.yaml
+++ b/helm-chart/banzai-nres/values-prod.yaml
@@ -12,7 +12,7 @@ horizontalPodAutoscaler:
 
 image:
   repository: docker.lco.global/banzai-nres
-  tag: "1.0.0"
+  tag: "1.0.1"
   pullPolicy: IfNotPresent
 
 # Values for the OCS Ingester library, used by BANZAI-NRES.

--- a/helm-chart/banzai-nres/values-prod.yaml
+++ b/helm-chart/banzai-nres/values-prod.yaml
@@ -38,6 +38,7 @@ banzaiNres:
   fitsExchange: archived_fits
   queueName: banzai_nres_pipeline
   phoenixFileLocation: s3://banzai-nres-phoenix-models-lco-global
+  celeryTaskQueueName: banzai_nres
 
 # CronJob configuration to periodically update instrument table in BANZAI DB
 instrumentTableCronjob:
@@ -54,5 +55,5 @@ postgresql:
 rabbitmq:
   hostname: rabbitmq-ha.prod.svc.cluster.local.
   rabbitmq:
-    username: banzai-nres
-  vhost: banzai-nres
+    username: banzai
+  vhost: banzai


### PR DESCRIPTION
Update to use banzai_nres task queue on BANZAI vhost within the H/A rabbitmq deployment. Update helm chart with required environment variables and configuration from upstream BANZAI.