### PR TITLE
fixed the wavelength 11/10s issue

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 1.0.2 (2021-06-01)
 ------------------
 - Changed SNR calculation to be per resolution element rather than per pixel
+- Fixed the extraction so that slightly mismatched trace regions and wavelength 
+files do not yield incorrect wavelengths. This resulted from ~1 pix noise
+in the center of the trace (in the super lampflats).
 
 1.0.1 (2021-05-24)
 ------------------

--- a/banzai_nres/extract.py
+++ b/banzai_nres/extract.py
@@ -32,9 +32,11 @@ class WeightedExtract(Stage):
             flux[i, x_extent] = self.extract_order(image.data[this_trace], image.weights[this_trace])
             variance[i, x_extent] = self.extract_order(image.uncertainty[this_trace] ** 2,
                                                        image.weights[this_trace] ** 2)
-            # get the average wavelength: Sum wavelengths weighted by 1 over the vertical width of the trace (e.g. 1/10)
-            wavelength[i, x_extent] = self.extract_order(image.wavelengths[this_trace],
-                                                         weights=1/image.wavelengths[this_trace].shape[0])
+            # TODO: some fix that allows for actual wavelength extraction:
+            # wavelength[i, x_extent] = self.extract_order(image.wavelengths[this_trace],
+            # weights=1/image.wavelengths[this_trace].shape[0])
+            wavelength[i, x_extent] = np.median(image.wavelengths[this_trace], axis=0)
+
             mask[i, x_extent] = image.weights[this_trace].sum(axis=0) == 0.0
 
         image.spectrum = Spectrum1D({'id': trace_ids, 'order': image.fibers['order'],


### PR DESCRIPTION
This fixes an issue that plagues a seemingly huge amount of data, whereby the wavelengths for ~10% of the pixels are off by exactly 10/11. This resulted from extracted a region of width 11, while it contained a single pixel in the wavelength image that had wavelength 0 (thereby biasing the result by 10/11). This results from wavelength calibrations using slightly different super trace files than science spectra (e.g., different by one night).

This PR implements a fully rigorous solution to the problem, so long as wavelengths are equal within a given column. 

For a given x pixel, We grab the median wavelength along each column, this is going to handle cases where up to 5 of the pixels in the 11 wide trace are zero -- e.g., np.median([5000]*6 + [0]*5) = 5000. So this handles up to a 5 pixel mismatch, which should never occur (the most we have seen is 1 pixel). This will therefore handle every feasible error. It would technically be more robust to use the mode, but we should be worried about different problems if the traces have shifted by more than 5 pixels.