### PR TITLE
Fix/snr resolution element

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+1.0.2 (2021-06-01)
+------------------
+- Changed SNR calculation to be per resolution element rather than per pixel
+
 1.0.1 (2021-05-24)
 ------------------
 - Add ability to configure task queue name (BANZAI 1.3.2)

--- a/banzai_nres/pdf.py
+++ b/banzai_nres/pdf.py
@@ -87,7 +87,8 @@ class MakePDFSummary(Stage):
         pl.text(0.1, top_line - line_separation * 8, 'Barycorr = {0:1.3f} km/s'.format(image.meta['BARYCORR'] / 1000.))
         pl.text(0.1, top_line - line_separation * 9, 'BJD_TDB = {0:1.5f}'.format(image.meta['TCORR']))
 
-        pl.text(0.1, top_line - line_separation * 11, 'SNR = {0:1.0f}/resolution element @ 5180 Angstroms'.format(image.meta['SNR']))
+        pl.text(0.1, top_line - line_separation * 11,
+                'SNR = {0:1.0f}/resolution element @ 5180 Angstroms'.format(image.meta['SNR']))
         pl.text(0.1, top_line - line_separation * 12, 'Exposure time = {0:1.0f} seconds'.format(image.meta['EXPTIME']))
 
         # Next Page

--- a/banzai_nres/pdf.py
+++ b/banzai_nres/pdf.py
@@ -68,7 +68,7 @@ class MakePDFSummary(Stage):
                     (order <= self.runtime_context.MAX_ORDER_TO_CORRELATE)
         pl.plot(snr_wavelength[rv_orders], snr[rv_orders], 'ro')
         pl.xlabel('wavelength (Angstroms)')
-        pl.ylabel('peak SNR/pixel in order')
+        pl.ylabel('peak SNR/resolution element in order')
         pl.title('SNR vs wavelength')
 
         ax = pl.subplot(2, 3, 6)
@@ -87,7 +87,7 @@ class MakePDFSummary(Stage):
         pl.text(0.1, top_line - line_separation * 8, 'Barycorr = {0:1.3f} km/s'.format(image.meta['BARYCORR'] / 1000.))
         pl.text(0.1, top_line - line_separation * 9, 'BJD_TDB = {0:1.5f}'.format(image.meta['TCORR']))
 
-        pl.text(0.1, top_line - line_separation * 11, 'SNR = {0:1.0f}/pixel @ 5180 Angstroms'.format(image.meta['SNR']))
+        pl.text(0.1, top_line - line_separation * 11, 'SNR = {0:1.0f}/resolution element @ 5180 Angstroms'.format(image.meta['SNR']))
         pl.text(0.1, top_line - line_separation * 12, 'Exposure time = {0:1.0f} seconds'.format(image.meta['EXPTIME']))
 
         # Next Page

--- a/banzai_nres/qc/qc_science.py
+++ b/banzai_nres/qc/qc_science.py
@@ -8,6 +8,8 @@ logger = logging.getLogger('banzai')
 # By default this is the order containing the Mg b lines.
 SNR_ORDER = 90
 
+PIXELS_PER_RESOLUTION_ELEMENT = 4.15
+
 
 class CalculateScienceFrameMetrics(Stage):
 
@@ -16,7 +18,7 @@ class CalculateScienceFrameMetrics(Stage):
 
     def do_stage(self, image):
         snr, snr_wave = get_snr(image, SNR_ORDER)
-        image.meta['SNR'] = snr, 'Signal-to-noise ratio per pix at 5180 Angstrom'
+        image.meta['SNR'] = snr, 'Signal-to-noise ratio per res element at 5180 Angstrom'
 
         image.meta['SCIFIBER'] = image.science_fiber, 'Fiber ID of the science spectrum'
 
@@ -27,5 +29,6 @@ def get_snr(image, order):
     snr_all = image.spectrum[image.science_fiber, order]['flux'] / \
               image.spectrum[image.science_fiber, order]['uncertainty']
     snr = np.percentile(snr_all, 90)
+    snr *= np.sqrt(PIXELS_PER_RESOLUTION_ELEMENT)
     snr_wave = np.mean(image.spectrum[image.science_fiber, order]['wavelength'][snr_all > snr])
     return snr, snr_wave

--- a/banzai_nres/qc/qc_science.py
+++ b/banzai_nres/qc/qc_science.py
@@ -8,6 +8,7 @@ logger = logging.getLogger('banzai')
 # By default this is the order containing the Mg b lines.
 SNR_ORDER = 90
 
+# TODO: measure the number of pixels per resolution element to verify this value.
 PIXELS_PER_RESOLUTION_ELEMENT = 4.15
 
 
@@ -18,7 +19,7 @@ class CalculateScienceFrameMetrics(Stage):
 
     def do_stage(self, image):
         snr, snr_wave = get_snr(image, SNR_ORDER)
-        image.meta['SNR'] = snr, 'Signal-to-noise ratio per res element at 5180 Angstrom'
+        image.meta['SNR'] = snr, 'Signal-to-noise ratio/res element @ 5180 Angstrom'
 
         image.meta['SCIFIBER'] = image.science_fiber, 'Fiber ID of the science spectrum'
 
@@ -29,6 +30,6 @@ def get_snr(image, order):
     snr_all = image.spectrum[image.science_fiber, order]['flux'] / \
               image.spectrum[image.science_fiber, order]['uncertainty']
     snr = np.percentile(snr_all, 90)
-    snr *= np.sqrt(PIXELS_PER_RESOLUTION_ELEMENT)
     snr_wave = np.mean(image.spectrum[image.science_fiber, order]['wavelength'][snr_all > snr])
+    snr *= np.sqrt(PIXELS_PER_RESOLUTION_ELEMENT)
     return snr, snr_wave

--- a/banzai_nres/settings.py
+++ b/banzai_nres/settings.py
@@ -174,6 +174,9 @@ PHOENIX_MODEL_AWS_SECRET_ACCESS_KEY = os.getenv('PHOENIX_MODEL_AWS_SECRET_ACCESS
 MIN_ORDER_TO_CORRELATE = 77
 MAX_ORDER_TO_CORRELATE = 97
 
+# TODO: measure the number of pixels per resolution element to verify this value.
+PIXELS_PER_RESOLUTION_ELEMENT = 4.15
+
 GAIA_CLASS = os.getenv('BANZAI_GAIA_CLASS', 'astroquery.gaia.GaiaClass')
 
 SIMBAD_CLASS = os.getenv('BANZAI_SIMBAD', 'astroquery.simbad.Simbad')

--- a/banzai_nres/tests/test_qc_science.py
+++ b/banzai_nres/tests/test_qc_science.py
@@ -9,7 +9,7 @@ from banzai.data import CCDData
 
 
 class TestCalculateScienceFrameMetrics:
-    input_context = context.Context({})
+    input_context = context.Context({'PIXELS_PER_RESOLUTION_ELEMENT': 4.15})
     test_wavelengths = np.linspace(5100.0, 5200.0, 4096)
     test_flux = -0.001 * test_wavelengths**2 + 10.3 * test_wavelengths
     test_uncertainty = np.sqrt(test_flux)
@@ -29,5 +29,6 @@ class TestCalculateScienceFrameMetrics:
         assert image is not None
 
     def test_snr_calculation(self):
-        snr, _ = get_snr(self.test_image, self.snr_order)
-        assert np.isclose(snr, np.max(self.test_flux/self.test_uncertainty), rtol=0.1)
+        snr, _ = get_snr(self.test_image, self.snr_order, self.input_context.PIXELS_PER_RESOLUTION_ELEMENT)
+        snr_test = self.test_flux/self.test_uncertainty * np.sqrt(self.input_context.PIXELS_PER_RESOLUTION_ELEMENT)
+        assert np.isclose(snr, np.max(snr_test), rtol=0.1)


### PR DESCRIPTION
This PR changes the calculation of the SNR for the spectra such that the quoted SNR is per resolution element rather than per pixel. This matches how this is quoted by the Commissioning Pipeline.