### PR TITLE
Temporarily disable worker autoscaling

### DIFF
--- a/helm-chart/banzai-nres/Chart.yaml
+++ b/helm-chart/banzai-nres/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "1.0.1"
+appVersion: "1.0.4"
 description: A Helm chart to deploy the BANZAI-NRES pipeline
 name: banzai-nres
-version: 1.0.1
+version: 1.0.4

--- a/helm-chart/banzai-nres/values-prod.yaml
+++ b/helm-chart/banzai-nres/values-prod.yaml
@@ -7,12 +7,12 @@
 horizontalPodAutoscaler:
   enabled: true
   minReplicas: 6
-  maxReplicas: 10
+  maxReplicas: 6
   targetCPUUtilizationPercentage: 50
 
 image:
   repository: docker.lco.global/banzai-nres
-  tag: "1.0.1"
+  tag: "1.0.4"
   pullPolicy: IfNotPresent
 
 # Values for the OCS Ingester library, used by BANZAI-NRES.


### PR DESCRIPTION
This is a temporary fix to the issue of in-progress celery tasks being truncated and not retried when a worker is brought down. Also update the helm chart to reflect the currently deployed pipeline.

This has been deployed since last week but I want to make sure it gets into version control.