### PR TITLE
Add filetype mapping, pull in new version of BANZAI

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+1.0.14 (2022-02-15)
+-------------------
+- Update upstream BANZAI install to use new version of OCS Ingester library (3.0.1)
+- Helm chart updates for ingester library
+
 1.0.13 (2022-02-14)
 -------------------
 - Update upstream BANZAI install to use new version of OCS Ingester library

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.lco.global/banzai:1.9.2
+FROM docker.lco.global/banzai:1.9.3
 
 USER root
 

--- a/helm-chart/banzai-nres/templates/_helpers.tpl
+++ b/helm-chart/banzai-nres/templates/_helpers.tpl
@@ -91,6 +91,8 @@ Ingester environment variables
   value: {{ .Values.ingester.s3Bucket | quote }}
 - name: FILESTORE_TYPE
   value: {{ .Values.ingester.filestoreType | quote }}
+- name: FILETYPE_MAPPING_OVERRIDES
+  value: {{ .Values.ingester.filetypeMappingOverrides | quote }}
 {{- if .Values.ingester.noMetrics }}
 - name: OPENTSDB_PYTHON_METRICS_TEST_MODE
   value: "1"

--- a/helm-chart/banzai-nres/values.yaml
+++ b/helm-chart/banzai-nres/values.yaml
@@ -31,6 +31,7 @@ securityContext:
 ingester:
   noMetrics: true
   postProcessFiles: false
+  filetypeMappingOverrides: "{'.fits': 'ocs_archive.input.lcofitsfile.LcoFitsFile', '.tar.gz': 'ocs_archive.input.lcotarwithfitsfile.LcoTarWithFitsFile'}"
 
 banzaiNres:
   useDifferentArchiveSources: false


### PR DESCRIPTION
BANZAI 1.9.3 will have the ocs_ingester 3.0.1 in it