### PR TITLE
Handle UNKNOWN coordinate, update broker URL

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+1.1.2 (2023-07-25)
+------------------
+- Update NRES Frame Factory to handle UNKNOWN as a valid empty coordinate
+
 1.1.0 (2023-04-04)
 ------------------
 - Added calibration frame comparison to reject them if they deviate too much from previous stacks

--- a/banzai_nres/frames.py
+++ b/banzai_nres/frames.py
@@ -367,7 +367,7 @@ class NRESFrameFactory(LCOFrameFactory):
 
     @staticmethod
     def is_empty_coordinate(coordinate):
-        return 'nan' in str(coordinate).lower() or 'n/a' in str(coordinate).lower()
+        return any(coordinate.lower() in value for value in ['nan', 'n/a', 'unknown'])
 
     def open(self, path, runtime_context) -> Optional[ObservationFrame]:
         image = super().open(path, runtime_context)

--- a/helm-chart/banzai-nres/values-prod.yaml
+++ b/helm-chart/banzai-nres/values-prod.yaml
@@ -34,7 +34,7 @@ banzaiNres:
   calibrateProposalId: calibrate
   banzaiWorkerLogLevel: info
   rawDataApiRoot: http://archiveapi-internal.prod/
-  fitsBroker: rabbitmq.lco.gtn
+  fitsBroker: rabbitmq-ha.prod.svc.cluster.local.
   fitsExchange: archived_fits
   queueName: banzai_nres_pipeline
   phoenixFileLocation: s3://banzai-nres-phoenix-models-lco-global


### PR DESCRIPTION
FITS keywords changed after Java17 upgrade (?) and we needed to handle UNKNOWN as an empty coordinate keyword, as well.

```python
In [1]: any('foo'.lower() in value for value in ['nan', 'n/a', 'unknown'])
Out[1]: False

In [2]: any('UNKNOWN'.lower() in value for value in ['nan', 'n/a', 'unknown'])
Out[2]: True

In [3]: any('NaN'.lower() in value for value in ['nan', 'n/a', 'unknown'])
Out[3]: True

In [4]: any('N/A'.lower() in value for value in ['nan', 'n/a', 'unknown'])
Out[4]: True
```