### PR TITLE
Update base version of banzai to 1.11.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+1.1.3 (2023-08-23)
+------------------
+- Update base version of BANZAI to 1.11.0
+
 1.1.2 (2023-07-25)
 ------------------
 - Update NRES Frame Factory to handle UNKNOWN as a valid empty coordinate

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.lco.global/banzai:1.9.8
+FROM docker.lco.global/banzai:1.11.0
 
 USER root
 


### PR DESCRIPTION
This keeps us up to date with banzai and also folds in some nice celery changes to automatically retry tasks when the workers die.