### PR TITLE
Make the large task queue the same as the normal.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+1.1.4 (2024-11-21)
+-----------------
+- Fix to helm chart to define large task queue as the same as normal task queue
+
 1.1.3 (2023-11-17)
 ------------------
 - Fixes to use BANZAI LoggingAdapter

--- a/helm-chart/banzai-nres/Chart.yaml
+++ b/helm-chart/banzai-nres/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart to deploy the BANZAI-NRES pipeline
 name: banzai-nres
-version: "1.1.0"
+version: "1.1.4"

--- a/helm-chart/banzai-nres/templates/_helpers.tpl
+++ b/helm-chart/banzai-nres/templates/_helpers.tpl
@@ -177,6 +177,8 @@ Celery task queue configuration
   value: {{ .Values.banzaiNres.queueName | quote }}
 - name: CELERY_TASK_QUEUE_NAME
   value: {{ .Values.banzaiNres.celeryTaskQueueName | quote }}
+- name: CELERY_LARGE_TASK_QUEUE_NAME
+  value: {{ .Values.banzaiNres.celeryTaskQueueName | quote }}
 - name: BANZAI_WORKER_LOGLEVEL
   value: {{ .Values.banzaiNres.banzaiWorkerLogLevel | quote }}
 - name: PHOENIX_FILE_LOCATION


### PR DESCRIPTION
This is to prevent the listener from creating another queue to route messages to that will never be acked.